### PR TITLE
Fix custom flag registration error handling

### DIFF
--- a/src/main/java/net/countercraft/movecraft/worldguard/MovecraftWorldGuard.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/MovecraftWorldGuard.java
@@ -25,13 +25,13 @@ public final class MovecraftWorldGuard extends JavaPlugin {
 
     @Override
     public void onLoad() {
+        instance = this;
+
         CustomFlags.register();
     }
 
     @Override
     public void onEnable() {
-        instance = this;
-
         saveDefaultConfig();
 
         // TODO other languages


### PR DESCRIPTION
The error handling in CustomFlags.java uses the plugin instance to log an error message, however currently the plugin instance is not assigned until later, causing a NullPointerException and failing to display the actual error.

This pull requests fixes that by moving the instance assignment to the beginning of onLoad rather than onEnable.