### PR TITLE
update java version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 group = "net.countercraft.movecraft.worldguard"
 version = "1.0.0_beta-5"
 description = "Movecraft-WorldGuard"
-java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 
 tasks.jar {
     archiveBaseName.set("Movecraft-WorldGuard")


### PR DESCRIPTION
Plugin couldn't compile unless I set the java version to 21, perhaps this is due to how movecraft-combat is compiled but not sure.