### PR TITLE
Add allow-craft-combat flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 group = "net.countercraft.movecraft.worldguard"
 version = "1.0.0_beta-5"
 description = "Movecraft-WorldGuard"
-java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 
 tasks.jar {
     archiveBaseName.set("Movecraft-WorldGuard")

--- a/src/main/java/net/countercraft/movecraft/worldguard/CustomFlags.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/CustomFlags.java
@@ -13,6 +13,7 @@ public class CustomFlags {
     public static final StateFlag ALLOW_CRAFT_SINK = new StateFlag("allow-craft-sink", false);
     public static final StateFlag ALLOW_CRAFT_TRANSLATE = new StateFlag("allow-craft-translate", false);
     public static final StateFlag ALLOW_CRAFT_REPAIR = new StateFlag("allow-craft-repair", false);
+    public static final StateFlag ALLOW_CRAFT_COMBAT = new StateFlag("allow-craft-combat", false);
 
     public static void register() {
         try {
@@ -23,6 +24,7 @@ public class CustomFlags {
             registry.register(ALLOW_CRAFT_SINK);
             registry.register(ALLOW_CRAFT_TRANSLATE);
             registry.register(ALLOW_CRAFT_REPAIR);
+            registry.register(ALLOW_CRAFT_COMBAT);
         }
         catch (Exception e) {
             MovecraftWorldGuard.getInstance().getLogger().log(

--- a/src/main/java/net/countercraft/movecraft/worldguard/MovecraftWorldGuard.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/MovecraftWorldGuard.java
@@ -73,6 +73,7 @@ public final class MovecraftWorldGuard extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new CraftTranslateListener(), this);
         getServer().getPluginManager().registerEvents(new FireSpreadListener(), this);
         getServer().getPluginManager().registerEvents(new ExplosionListener(), this);
+        getServer().getPluginManager().registerEvents(new ProjectileHitListener(), this);
     }
 
     public WorldGuardUtils getWGUtils() {

--- a/src/main/java/net/countercraft/movecraft/worldguard/MovecraftWorldGuard.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/MovecraftWorldGuard.java
@@ -71,6 +71,7 @@ public final class MovecraftWorldGuard extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new CraftRotateListener(), this);
         getServer().getPluginManager().registerEvents(new CraftSinkListener(), this);
         getServer().getPluginManager().registerEvents(new CraftTranslateListener(), this);
+        getServer().getPluginManager().registerEvents(new FireSpreadListener(), this);
         getServer().getPluginManager().registerEvents(new ExplosionListener(), this);
     }
 

--- a/src/main/java/net/countercraft/movecraft/worldguard/listener/ExplosionListener.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/listener/ExplosionListener.java
@@ -1,10 +1,30 @@
 package net.countercraft.movecraft.worldguard.listener;
 
 import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.events.ExplosionEvent;
+import net.countercraft.movecraft.util.MathUtils;
+import net.countercraft.movecraft.worldguard.CustomFlags;
 import net.countercraft.movecraft.worldguard.MovecraftWorldGuard;
+import net.countercraft.movecraft.worldguard.utils.WorldGuardUtils;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.text.html.parser.Entity;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 public class ExplosionListener implements Listener {
     @EventHandler
@@ -21,5 +41,64 @@ public class ExplosionListener implements Listener {
             default:
                 break;
         }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onEntityExplosion(EntityExplodeEvent e) {
+        e.blockList().removeAll(getProtectedBlocks(e.blockList()));
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onTorpedoExplosion(BlockExplodeEvent e) {
+        e.blockList().removeAll(getProtectedBlocks(e.blockList()));
+    }
+
+    private List<Block> getProtectedBlocks(List<Block> blocks) {
+        List<Block> protectedBlocks = new ArrayList<>();
+        for (Block block : blocks) {
+            WorldGuardUtils.State state = MovecraftWorldGuard.getInstance().getWGUtils().getState(
+                    null, block.getLocation(), CustomFlags.ALLOW_CRAFT_COMBAT);
+            if (state == WorldGuardUtils.State.ALLOW) {
+                MovecraftLocation loc = MathUtils.bukkit2MovecraftLoc(block.getLocation());
+                Craft craft = fastNearestCraftToLoc(block.getLocation());
+                if (craft == null) {
+                    protectedBlocks.add(block);
+                    System.out.println("Protected block added!");
+                    continue;
+                }
+                if (!craft.getHitBox().contains(loc)) {
+                    protectedBlocks.add(block);
+                    System.out.println("Protected block added!");
+                }
+            } else if (state == WorldGuardUtils.State.DENY) {
+                MovecraftLocation loc = MathUtils.bukkit2MovecraftLoc(block.getLocation());
+                Craft craft = fastNearestCraftToLoc(block.getLocation());
+                if (craft == null) {
+                    continue;
+                }
+                if (craft.getHitBox().contains(loc)) {
+                    protectedBlocks.add(block);
+                    System.out.println("Protected block added!");
+                }
+            }
+        }
+        return protectedBlocks;
+    }
+
+    private Craft fastNearestCraftToLoc(@NotNull Location source) {
+        MovecraftLocation loc = MathUtils.bukkit2MovecraftLoc(source);
+        Craft closest = null;
+        long closestDistSquared = Long.MAX_VALUE;
+        for (Craft other : CraftManager.getInstance()) {
+            if (other.getWorld() != source.getWorld())
+                continue;
+
+            long distSquared = other.getHitBox().getMidPoint().distanceSquared(loc);
+            if (distSquared < closestDistSquared) {
+                closestDistSquared = distSquared;
+                closest = other;
+            }
+        }
+        return closest;
     }
 }

--- a/src/main/java/net/countercraft/movecraft/worldguard/listener/ExplosionListener.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/listener/ExplosionListener.java
@@ -56,32 +56,8 @@ public class ExplosionListener implements Listener {
     private List<Block> getProtectedBlocks(List<Block> blocks) {
         List<Block> protectedBlocks = new ArrayList<>();
         for (Block block : blocks) {
-            MovecraftLocation loc = MathUtils.bukkit2MovecraftLoc(block.getLocation());
-            Craft craft = MathUtils.fastNearestCraftToLoc(
-                    CraftManager.getInstance().getCraftsInWorld(block.getWorld()),
-                    block.getLocation()
-            );
-            switch (MovecraftWorldGuard.getInstance().getWGUtils().getState(
-                    null, block.getLocation(), CustomFlags.ALLOW_CRAFT_COMBAT)) {
-                case ALLOW:
-                    if (craft == null) {
-                        protectedBlocks.add(block);
-                        continue;
-                    }
-                    if (!craft.getHitBox().contains(loc)) {
-                        protectedBlocks.add(block);
-                    }
-                case NONE:
-                    break;
-                case DENY:
-                    if (craft == null) {
-                        continue;
-                    }
-                    if (craft.getHitBox().contains(loc)) {
-                        protectedBlocks.add(block);
-                    }
-                default:
-                    break;
+            if (MovecraftWorldGuard.getInstance().getWGUtils().isProtectedFromBreak(block)) {
+                protectedBlocks.add(block);
             }
         }
         return protectedBlocks;

--- a/src/main/java/net/countercraft/movecraft/worldguard/listener/FireSpreadListener.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/listener/FireSpreadListener.java
@@ -16,46 +16,11 @@ import org.bukkit.event.block.BlockSpreadEvent;
 public class FireSpreadListener implements Listener {
     @EventHandler
     public void onIgnite(BlockIgniteEvent event) {
-        event.setCancelled(fireCheck(event.getBlock()));
+        event.setCancelled(MovecraftWorldGuard.getInstance().getWGUtils().isProtectedFromBreak(event.getBlock()));
     }
 
     @EventHandler
     public void onBurn(BlockBurnEvent event) {
-        event.setCancelled(fireCheck(event.getBlock()));
-    }
-
-    private boolean fireCheck(Block block) {
-        MovecraftLocation loc = MathUtils.bukkit2MovecraftLoc(block.getLocation());
-        Craft craft = MathUtils.fastNearestCraftToLoc(
-                CraftManager.getInstance().getCraftsInWorld(block.getWorld()),
-                block.getLocation()
-        );
-        switch (MovecraftWorldGuard.getInstance().getWGUtils().getState(
-                null, block.getLocation(), CustomFlags.ALLOW_CRAFT_COMBAT)) {
-            case ALLOW:
-                // Protect the area outside the craft
-                if (craft == null) {
-                    return true;
-                }
-                if (!craft.getHitBox().contains(loc)) {
-                    System.out.println("Protected!");
-                    return true;
-                }
-                break;
-            case DENY:
-                // Protect the block if fire occurs inside craft
-                if (craft == null) {
-                    break;
-                }
-                if (craft.getHitBox().contains(loc)) {
-                    System.out.println("Protected!");
-                    return true;
-                }
-                break;
-            default:
-                break;
-        }
-        System.out.println("Not protected");
-        return false;
+        event.setCancelled(MovecraftWorldGuard.getInstance().getWGUtils().isProtectedFromBreak(event.getBlock()));
     }
 }

--- a/src/main/java/net/countercraft/movecraft/worldguard/listener/FireSpreadListener.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/listener/FireSpreadListener.java
@@ -1,0 +1,24 @@
+package net.countercraft.movecraft.worldguard.listener;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBurnEvent;
+import org.bukkit.event.block.BlockIgniteEvent;
+import org.bukkit.event.block.BlockSpreadEvent;
+
+public class FireSpreadListener implements Listener {
+    @EventHandler
+    public void onIgnite(BlockIgniteEvent event) {
+
+    }
+
+    @EventHandler
+    public void onBurn(BlockBurnEvent event) {
+
+    }
+
+    @EventHandler
+    public void onSpread(BlockSpreadEvent event) {
+
+    }
+}

--- a/src/main/java/net/countercraft/movecraft/worldguard/listener/FireSpreadListener.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/listener/FireSpreadListener.java
@@ -1,5 +1,12 @@
 package net.countercraft.movecraft.worldguard.listener;
 
+import net.countercraft.movecraft.MovecraftLocation;
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.CraftManager;
+import net.countercraft.movecraft.util.MathUtils;
+import net.countercraft.movecraft.worldguard.CustomFlags;
+import net.countercraft.movecraft.worldguard.MovecraftWorldGuard;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBurnEvent;
@@ -9,16 +16,46 @@ import org.bukkit.event.block.BlockSpreadEvent;
 public class FireSpreadListener implements Listener {
     @EventHandler
     public void onIgnite(BlockIgniteEvent event) {
-
+        event.setCancelled(fireCheck(event.getBlock()));
     }
 
     @EventHandler
     public void onBurn(BlockBurnEvent event) {
-
+        event.setCancelled(fireCheck(event.getBlock()));
     }
 
-    @EventHandler
-    public void onSpread(BlockSpreadEvent event) {
-
+    private boolean fireCheck(Block block) {
+        MovecraftLocation loc = MathUtils.bukkit2MovecraftLoc(block.getLocation());
+        Craft craft = MathUtils.fastNearestCraftToLoc(
+                CraftManager.getInstance().getCraftsInWorld(block.getWorld()),
+                block.getLocation()
+        );
+        switch (MovecraftWorldGuard.getInstance().getWGUtils().getState(
+                null, block.getLocation(), CustomFlags.ALLOW_CRAFT_COMBAT)) {
+            case ALLOW:
+                // Protect the area outside the craft
+                if (craft == null) {
+                    return true;
+                }
+                if (!craft.getHitBox().contains(loc)) {
+                    System.out.println("Protected!");
+                    return true;
+                }
+                break;
+            case DENY:
+                // Protect the block if fire occurs inside craft
+                if (craft == null) {
+                    break;
+                }
+                if (craft.getHitBox().contains(loc)) {
+                    System.out.println("Protected!");
+                    return true;
+                }
+                break;
+            default:
+                break;
+        }
+        System.out.println("Not protected");
+        return false;
     }
 }

--- a/src/main/java/net/countercraft/movecraft/worldguard/listener/ProjectileHitListener.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/listener/ProjectileHitListener.java
@@ -1,0 +1,16 @@
+package net.countercraft.movecraft.worldguard.listener;
+
+import net.countercraft.movecraft.worldguard.MovecraftWorldGuard;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ProjectileHitEvent;
+
+public class ProjectileHitListener implements Listener {
+    @EventHandler
+    public void onProjectileHit(ProjectileHitEvent event) {
+        if (event.getHitBlock() == null) {
+            return;
+        }
+        event.setCancelled(MovecraftWorldGuard.getInstance().getWGUtils().isProtectedFromBreak(event.getHitBlock()));
+    }
+}

--- a/src/main/java/net/countercraft/movecraft/worldguard/utils/WorldGuardUtils.java
+++ b/src/main/java/net/countercraft/movecraft/worldguard/utils/WorldGuardUtils.java
@@ -14,7 +14,9 @@ import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.exception.EmptyHitBoxException;
+import net.countercraft.movecraft.util.MathUtils;
 import net.countercraft.movecraft.util.Pair;
 import net.countercraft.movecraft.util.hitboxes.HitBox;
 import org.bukkit.Bukkit;
@@ -404,5 +406,26 @@ public class WorldGuardUtils {
             }
         }
         return corners;
+    }
+
+    /**
+     * @param source Location of the block
+     * @return The closest craft to the block. If the block is within the craft, it should return it.
+     */
+    private Craft fastNearestCraftToLoc(@NotNull Location source) {
+        MovecraftLocation loc = MathUtils.bukkit2MovecraftLoc(source);
+        Craft closest = null;
+        long closestDistSquared = Long.MAX_VALUE;
+        for (Craft other : CraftManager.getInstance()) {
+            if (other.getWorld() != source.getWorld())
+                continue;
+
+            long distSquared = other.getHitBox().getMidPoint().distanceSquared(loc);
+            if (distSquared < closestDistSquared) {
+                closestDistSquared = distSquared;
+                closest = other;
+            }
+        }
+        return closest;
     }
 }


### PR DESCRIPTION
Basically this flag allows fire, tnt, and projectile damage (for cannons) to affect a craft vs terrain. Setting the flag to allow makes it so only craft blocks take damage but setting it to deny makes only terrain take damage. 